### PR TITLE
fix: zsh shebangs & remove comments in zsd files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash
+.ONESHELL:
 MAKEFLAGS += --silent
 NAME=zshelldoc
 
@@ -11,61 +13,53 @@ all: build/zsd build/zsd-transform build/zsd-detect build/zsd-to-adoc
 
 build/zsd: src/zsd.preamble src/zsd.main
 	mkdir -p build
-	rm -f build/zsd
-	cat src/zsd.preamble > build/zsd
-	echo "" >> build/zsd
-	cat src/zsd.main >> build/zsd
+	cat /dev/null > build/zsd
+	echo '#!/usr/bin/env zsh' >> build/zsd
+	cat src/zsd.preamble | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd
+	cat src/zsd.main | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd
 	chmod +x build/zsd
-	$(info zsd built)
+	$(info generated zsd)
 
 build/zsd-transform: src/zsd-transform.preamble src/zsd-transform.main src/zsd-process-buffer src/zsd-trim-indent
 	mkdir -p build
-	rm -f build/zsd-transform
-	cat src/zsd-transform.preamble > build/zsd-transform
-	echo "" >> build/zsd-transform
+	cat /dev/null > build/zsd-transform
+	echo "#!/usr/bin/env zsh" >> build/zsd-transform
+	cat src/zsd-transform.preamble| grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-transform
 	echo "zsd-process-buffer() {" >> build/zsd-transform
-	cat src/zsd-process-buffer >> build/zsd-transform
+	cat src/zsd-process-buffer | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-transform
+	echo -e "}\nzsd-trim-indent() {" >> build/zsd-transform
+	cat src/zsd-trim-indent | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-transform
 	echo "}" >> build/zsd-transform
-	echo "" >> build/zsd-transform
-	echo "zsd-trim-indent() {" >> build/zsd-transform
-	cat src/zsd-trim-indent >> build/zsd-transform
-	echo "}" >> build/zsd-transform
-	echo "" >> build/zsd-transform
-	cat src/token-types.mod >> build/zsd-transform
-	echo "" >> build/zsd-transform
-	cat src/zsd-transform.main >> build/zsd-transform
+	cat src/token-types.mod | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-transform
+	cat src/zsd-transform.main | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-transform
 	chmod +x build/zsd-transform
-	$(info zsd-transform built)
+	$(info generated zsd-transform)
 
 build/zsd-detect: src/zsd-detect.preamble src/zsd-detect.main src/zsd-process-buffer src/run-tree-convert.mod src/token-types.mod
 	mkdir -p build
-	rm -f build/zsd-detect
-	cat src/zsd-detect.preamble > build/zsd-detect
-	echo "" >> build/zsd-detect
+	cat /dev/null > build/zsd-detect
+	echo "#!/usr/bin/env zsh" >> build/zsd-detect
+	cat src/zsd-detect.preamble | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-detect
 	echo "zsd-process-buffer() {" >> build/zsd-detect
-	cat src/zsd-process-buffer >> build/zsd-detect
+	cat src/zsd-process-buffer | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-detect
 	echo "}" >> build/zsd-detect
-	echo "" >> build/zsd-detect
-	cat src/run-tree-convert.mod >> build/zsd-detect
-	echo "" >> build/zsd-detect
-	cat src/token-types.mod >> build/zsd-detect
-	echo "" >> build/zsd-detect
-	cat src/zsd-detect.main >> build/zsd-detect
+	cat src/run-tree-convert.mod | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-detect
+	cat src/token-types.mod | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-detect
+	cat src/zsd-detect.main | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-detect
 	chmod +x build/zsd-detect
-	$(info zsd-detect built)
+	$(info generated zsd-detect)
 
 build/zsd-to-adoc: src/zsd-to-adoc.preamble src/zsd-to-adoc.main src/zsd-trim-indent
 	mkdir -p build
-	rm -f build/zsd-to-adoc
-	cat src/zsd-to-adoc.preamble > build/zsd-to-adoc
-	echo "" >> build/zsd-to-adoc
+	cat /dev/null > build/zsd-to-adoc
+	echo "#!/usr/bin/env zsh" >> build/zsd-to-adoc
+	cat src/zsd-to-adoc.preamble | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-to-adoc
 	echo "zsd-trim-indent() {" >> build/zsd-to-adoc
-	cat src/zsd-trim-indent >> build/zsd-to-adoc
+	cat src/zsd-trim-indent | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-to-adoc
 	echo "}" >> build/zsd-to-adoc
-	echo "" >> build/zsd-to-adoc
-	cat src/zsd-to-adoc.main >> build/zsd-to-adoc
+	cat src/zsd-to-adoc.main | grep -v -E '^(\s*#.*[^"]|\s*)$$' >> build/zsd-to-adoc
 	chmod +x build/zsd-to-adoc
-	$(info zsd-to-adoc built)
+	$(info generated zsd-to-adoc)
 
 install: build/zsd build/zsd-detect build/zsd-transform build/zsd-to-adoc
 	$(INSTALL) -d $(SHARE_DIR)
@@ -89,3 +83,5 @@ test:
 	make -C test test
 
 .PHONY: all install uninstall test clean
+
+# vim: set expandtab filetype=make shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/run-tree-convert.mod
+++ b/src/run-tree-convert.mod
@@ -31,3 +31,5 @@ zsd-run-tree-convert () {
         } >&2
     fi
 }
+
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/token-types.mod
+++ b/src/token-types.mod
@@ -44,4 +44,4 @@ TOKEN_TYPES=(
     '|&' 4
 )
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-detect.main
+++ b/src/zsd-detect.main
@@ -374,4 +374,4 @@ for fun_name in "${(ko@)env_list}"; do
 done
 return 0
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-detect.preamble
+++ b/src/zsd-detect.preamble
@@ -59,4 +59,4 @@ process_node () {
     PROCESSED[-1]=()
 }
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-process-buffer
+++ b/src/zsd-process-buffer
@@ -80,4 +80,4 @@ ZSD_PB_RIGHT=${word[diff+1,-1]}
 
 return 0
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-to-adoc.main
+++ b/src/zsd-to-adoc.main
@@ -1,4 +1,3 @@
-# vim:ft=zsh:et:sw=4
 # This file is double-licensed under GPLv3 and MIT (see LICENSE file)
 
 ### Options ###
@@ -360,3 +359,5 @@ command rm -f -- zsdoc/$ofname
 
 print -P -- "%F{blue}==>%f created %B%F{green}$ofname%f%b in directory ${PWD}/doc/zsdoc/ "
 return 0
+
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-to-adoc.preamble
+++ b/src/zsd-to-adoc.preamble
@@ -13,4 +13,4 @@ local -A colors
 autoload colors
 colors 2>/dev/null
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-transform.main
+++ b/src/zsd-transform.main
@@ -241,4 +241,4 @@ for fun_name in "${(ko@)myexports}"; do
 done
 return 0
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-transform.preamble
+++ b/src/zsd-transform.preamble
@@ -29,4 +29,4 @@ zsd::transform-usage() {
 EOF
 }
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd-trim-indent
+++ b/src/zsd-trim-indent
@@ -36,4 +36,4 @@ done
 
 REPLY="${(F)new_lines}"
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd.main
+++ b/src/zsd.main
@@ -150,4 +150,4 @@ fi
 
 return $ret
 
-# vim: set expandtab filetype=zsh shiftwidth=2 softtabstop=2 tabstop=2:
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:

--- a/src/zsd.preamble
+++ b/src/zsd.preamble
@@ -83,3 +83,5 @@ zsd::usage () {
         ' "Change the default brace block-delimeters with --blocka, --blockb. Block body should be AsciiDoc")
     print -Prl -- $usage
 }
+
+# vim: set expandtab filetype=zsh shiftwidth=4 softtabstop=4 tabstop=4:


### PR DESCRIPTION
## Description

Update Makefile targets that build zsd* files:
- remove comments to shrink size
- correct zsh shebangs

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
